### PR TITLE
Use request.query instead of removed request.GET

### DIFF
--- a/aiohttp_datadog/__init__.py
+++ b/aiohttp_datadog/__init__.py
@@ -21,7 +21,7 @@ class DatadogMiddleware:
             'http_version:{0}'.format(request.version),
             'http_host:{0}'.format(request.host),
             'http_path:{0}'.format(request.path),
-            'request_type:{0}'.format(request.GET.getone('type', None)),
+            'request_type:{0}'.format(request.query.getone('type', None)),
         ]
 
         with self.dogstatsd.timed('{0}.request.time'.format(self.app_prefix), tags=tags):


### PR DESCRIPTION
request.GET was deprecated before and removed in aiohttp 3.0:
https://github.com/aio-libs/aiohttp/issues/2547